### PR TITLE
Update Labeler to enabled "Label Sync"

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,4 +16,5 @@ jobs:
     steps:
     - uses: actions/labeler@v2
       with:
+        sync-labels: true
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Currently, the label action only adds labels, it won't touch existing labels. In a recent release they added this capability to sync labels (i.e. remove them if no longer applicable). 


Since we don't use the PR labels on this repo for anything else other than this automatically for footprints/symbols/kicad_libraries labels etc. it makes sense to enable this. Now if someone accidentally changes the Kicad Libraries and then fixes it the bad red label will go away automatically!