### PR TITLE
Updated Labeler to v3 for Sync

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,6 +19,6 @@ kicad libraries:
 
 # Add git label to anything that changes a repo config
 git:
-  - .github/*
+  - .github/**/*
   - '**/.gitignore'
   - ./*.md

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v3
       with:
         sync-labels: true
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/schematic_kicad/4xxx.dcm
+++ b/schematic_kicad/4xxx.dcm
@@ -2,7 +2,7 @@ EESchema-DOCLIB  Version 2.0
 #
 $CMP 14528
 D Monostable
-K CMOS test
+K CMOS
 F https://www.onsemi.com/pub/Collateral/MC14528B-D.PDF
 $ENDCMP
 #

--- a/schematic_kicad/4xxx.dcm
+++ b/schematic_kicad/4xxx.dcm
@@ -2,7 +2,7 @@ EESchema-DOCLIB  Version 2.0
 #
 $CMP 14528
 D Monostable
-K CMOS
+K CMOS test
 F https://www.onsemi.com/pub/Collateral/MC14528B-D.PDF
 $ENDCMP
 #


### PR DESCRIPTION
Previously there was a PR to enable syncing labels (#60 ). This would remove labels when, for example, someone undid their changes to KiCad Libraries thus keeping the labels accurate. 

This functionality was pulled from v2, which is why it is not currently working. This PR updates the labeler to v3 and demonstrates that it works